### PR TITLE
android_linker_ns.cpp: Replace `PAGE_SIZE` with `getpagesize()`

### DIFF
--- a/android_linker_ns.cpp
+++ b/android_linker_ns.cpp
@@ -122,7 +122,7 @@ void *linkernsbypass_namespace_dlopen_unique(const char *libPath, const char *li
 }
 
 static void *align_ptr(void *ptr) {
-    return reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(ptr) & ~(PAGE_SIZE - 1));
+    return reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(ptr) & ~(getpagesize() - 1));
 }
 
 /* Private */
@@ -149,7 +149,7 @@ __attribute__((constructor)) static void resolve_linker_symbols() {
         static_assert(sizeof(BranchLinked) == 4, "BranchLinked is wrong size");
 
         // Some devices ship with --X mapping for exexecutables so work around that
-        mprotect(align_ptr(reinterpret_cast<void *>(&dlopen)), PAGE_SIZE, PROT_WRITE | PROT_READ | PROT_EXEC);
+        mprotect(align_ptr(reinterpret_cast<void *>(&dlopen)), getpagesize(), PROT_WRITE | PROT_READ | PROT_EXEC);
 
         // dlopen is just a wrapper for __loader_dlopen that passes the return address as the third arg hence we can just walk it to find __loader_dlopen
         auto blInstr{reinterpret_cast<BranchLinked *>(&dlopen)};
@@ -160,7 +160,7 @@ __attribute__((constructor)) static void resolve_linker_symbols() {
     }()};
 
     // Protect the loader_dlopen function to remove the BTI attribute (since this is an internal function that isn't intended to be jumped indirectly to)
-    mprotect(align_ptr(reinterpret_cast<void *>(&loader_dlopen)), PAGE_SIZE, PROT_WRITE | PROT_READ | PROT_EXEC);
+    mprotect(align_ptr(reinterpret_cast<void *>(&loader_dlopen)), getpagesize(), PROT_WRITE | PROT_READ | PROT_EXEC);
 
     // Passing dlopen as a caller address tricks the linker into using the internal unrestricted namespace letting us access libraries that are normally forbidden in the classloader namespace imposed on apps
     auto ldHandle{loader_dlopen("ld-android.so", RTLD_LAZY, reinterpret_cast<void *>(&dlopen))};


### PR DESCRIPTION
Android 15 will allow OEMs to ship arm64-v8a devices with 16KiB page sizes. Devices that use this configuration will not be able to run existing apps that use native code. To be compatible with these devices, applications will need to rebuild all their native code to be 16KiB aligned, and rewrite any code which assumes a specific page size.

This change should allow for page size to be calculated dynamically to support these new devices.